### PR TITLE
fix: update DistributionDir for Angular

### DIFF
--- a/packages/amplify-frontend-javascript/lib/framework-config-mapping.js
+++ b/packages/amplify-frontend-javascript/lib/framework-config-mapping.js
@@ -68,11 +68,20 @@ function getAngularConfig(context, projectPath) {
     context.usageData.emitError(new AngularConfigNotFoundError(errorMessage));
     exitOnNextTick(1);
   }
-  const dist = _.get(
-    angularProjectConfig,
-    ['projects', angularProjectConfig.defaultProject, 'architect', 'build', 'options', 'outputPath'],
-    'dist',
-  );
+
+  let dist = 'dist';
+  try {
+    const firstProject = Object.values(angularProjectConfig.projects)[0];
+    const {builder, options} = firstProject.architect.build;
+    dist = options.outputPath;
+    if (builder === '@angular-devkit/build-angular:application') {
+      // The application builder will output browser files in /browser and server files in /server.
+      dist + '/browser';
+    }
+  } catch {
+    context.print.info(`Failed to determine DistributionDir.`);
+  }
+
   return {
     ...angularConfig,
     DistributionDir: dist,


### PR DESCRIPTION
This commit fixes an issue that for the Angular preset, the DistributionDir was not detected correctly as the `defaultProject` has been removed from the angular.json some major versions ago. 

This change also adds support for an upcoming change in version 17 were there is a new "builder".
